### PR TITLE
Change DigitalOcean logo URL to local image

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
   
         <center>
             <p>
-                <a href="https://www.digitalocean.com/?refcode=afe991ab278c"><img src="https://www.digitalocean.com/assets/images/logos-badges/png/DO_Proudly_Hosted_Badge_Grey-1652c782.png" width="150" height="40"></a>
+                <a href="https://www.digitalocean.com/?refcode=afe991ab278c"><img src="http://whyubuntuisbetter.com/img/DO_Proudly_Hosted_Badge_Grey-1652c782.png" width="150" height="40"></a>
             </p>
             <p>This site is maintained by <a href="mailto:me@mariogrip.com">Marius Gripsgård</a> and is not an any way endorsed by or affiliated with <a href="http://ubuntu.com/">Ubuntu</a> or <a href="http://www.canonical.com/">Canonical</a>. <a href="http://ubuntu.com/">Ubuntu</a> and <a href="http://www.canonical.com/">Canonical</a> are registered trademarks of <a href="http://www.canonical.com/">Canonical Ltd.</a></p>
             <p>This webpage is build with AngularJS and inspired by <a href="http://whylinuxisbetter.net/">whylinuxisbetter.net</a> </p>


### PR DESCRIPTION
Fixes blank image at bottom of page caused by DO not allowing hotlinking images.
